### PR TITLE
Add BUILD_TESTING option to cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,43 +28,48 @@ cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 20)
 project(FPDataGeneration)
 
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
-)
-FetchContent_MakeAvailable(googletest)
-
-enable_testing()
-
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-strict-aliasing -Wno-error=strict-aliasing -fsanitize=undefined)
-add_link_options(-fsanitize=undefined)
+option(BUILD_TESTING "Build mxDataGenerator test clients" ON)
 
 find_package(OpenMP)
 add_library(mxDataGenerator INTERFACE)
 target_link_libraries(mxDataGenerator INTERFACE OpenMP::OpenMP_CXX)
 target_include_directories(mxDataGenerator INTERFACE lib/include)
 
-add_executable(
-  mxDataGeneratorTests
+if(BUILD_TESTING)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+  )
+  FetchContent_MakeAvailable(googletest)
 
-  test/data_generator_test.cpp
-  test/f32_test.cpp
-  test/fp16_test.cpp
-  test/bf16_test.cpp
-  test/ocp_e4m3_mxfp8_test.cpp
-  test/ocp_e5m2_mxfp8_test.cpp
-  test/ocp_e2m3_mxfp6_test.cpp
-  test/ocp_e3m2_mxfp6_test.cpp
-  test/ocp_e2m1_mxfp4_test.cpp
-)
+  enable_testing()
 
-target_link_libraries(
-  mxDataGeneratorTests PRIVATE
-  GTest::gtest_main
-  mxDataGenerator
-  OpenMP::OpenMP_CXX
-)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-strict-aliasing -Wno-error=strict-aliasing -fsanitize=undefined)
+  add_link_options(-fsanitize=undefined)
 
-include(GoogleTest)
-gtest_discover_tests(mxDataGeneratorTests DISCOVERY_MODE PRE_TEST)
+  add_executable(
+    mxDataGeneratorTests
+
+    test/data_generator_test.cpp
+    test/f32_test.cpp
+    test/fp16_test.cpp
+    test/bf16_test.cpp
+    test/ocp_e4m3_mxfp8_test.cpp
+    test/ocp_e5m2_mxfp8_test.cpp
+    test/ocp_e2m3_mxfp6_test.cpp
+    test/ocp_e3m2_mxfp6_test.cpp
+    test/ocp_e2m1_mxfp4_test.cpp
+  )
+
+  target_link_libraries(
+    mxDataGeneratorTests PRIVATE
+    GTest::gtest_main
+    mxDataGenerator
+    OpenMP::OpenMP_CXX
+  )
+
+  include(GoogleTest)
+  gtest_discover_tests(mxDataGeneratorTests DISCOVERY_MODE PRE_TEST)
+
+endif()


### PR DESCRIPTION
This PR adds a BUILD_TESTING option to the cmake file. This will allow projects including mxDataGenerator to not build the mxDataGenerator tests.