### PR TITLE
Use 64-bit integers for indexing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if(MXDATAGENERATOR_BUILD_TESTING)
       test/ocp_e2m1_mxfp4_test.cpp
     )
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(mxDataGeneratorTests PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-strict-aliasing -Wno-error=strict-aliasing -fsanitize=undefined)
+        target_compile_options(mxDataGeneratorTests PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-strict-aliasing -Wno-error=strict-aliasing)
         target_link_options(mxDataGeneratorTests PRIVATE -fsanitize=undefined)
     endif()
     target_link_libraries(

--- a/lib/include/bf16_impl.hpp
+++ b/lib/include/bf16_impl.hpp
@@ -32,8 +32,8 @@
 template <>
 inline bool isNaN<bf16>(uint8_t const* scaleBytes [[maybe_unused]],
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex [[maybe_unused]],
-                        size_t         dataIndex)
+                        index_t         scaleIndex [[maybe_unused]],
+                        index_t         dataIndex)
 {
     uint16_t data = getDataFP16(dataBytes, dataIndex);
 
@@ -47,8 +47,8 @@ inline bool isNaN<bf16>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isZero<bf16>(uint8_t const* scaleBytes,
                          uint8_t const* dataBytes,
-                         size_t         scaleIndex,
-                         size_t         dataIndex)
+                         index_t         scaleIndex,
+                         index_t         dataIndex)
 {
 
     if(isNaN<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex))
@@ -62,8 +62,8 @@ inline bool isZero<bf16>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<bf16>(uint8_t const* scaleBytes [[maybe_unused]],
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex [[maybe_unused]],
-                        size_t         dataIndex)
+                        index_t         scaleIndex [[maybe_unused]],
+                        index_t         dataIndex)
 {
     uint16_t data = getDataFP16(dataBytes, dataIndex);
     return (data & bf16::setSignMask) == bf16::dataInfMask;
@@ -73,8 +73,8 @@ inline bool isInf<bf16>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline double toDouble<bf16>(uint8_t const* scaleBytes,
                              uint8_t const* dataBytes,
-                             size_t         scaleIndex,
-                             size_t         dataIndex)
+                             index_t         scaleIndex,
+                             index_t         dataIndex)
 {
 
     if(isNaN<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex))
@@ -109,8 +109,8 @@ inline double toDouble<bf16>(uint8_t const* scaleBytes,
 template <>
 inline float toFloat<bf16>(uint8_t const* scaleBytes,
                            uint8_t const* dataBytes,
-                           size_t         scaleIndex,
-                           size_t         dataIndex)
+                           index_t         scaleIndex,
+                           index_t         dataIndex)
 {
     if(isNaN<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -145,8 +145,8 @@ inline float toFloat<bf16>(uint8_t const* scaleBytes,
 template <>
 inline bool isOne<bf16>(uint8_t const* scaleBytes,
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex,
-                        size_t         dataIndex)
+                        index_t         scaleIndex,
+                        index_t         dataIndex)
 {
     return toDouble<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex) == 1.0;
 }
@@ -156,8 +156,8 @@ template <>
 inline bool isLess<bf16>(double         val,
                          uint8_t const* scaleBytes,
                          uint8_t const* dataBytes,
-                         size_t         scaleIndex,
-                         size_t         dataIndex)
+                         index_t         scaleIndex,
+                         index_t         dataIndex)
 {
     return toDouble<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex) < val;
 }
@@ -167,8 +167,8 @@ template <>
 inline bool isGreater<bf16>(double         val,
                             uint8_t const* scaleBytes,
                             uint8_t const* dataBytes,
-                            size_t         scaleIndex,
-                            size_t         dataIndex)
+                            index_t         scaleIndex,
+                            index_t         dataIndex)
 {
     return toDouble<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex) > val;
 }
@@ -177,8 +177,8 @@ inline bool isGreater<bf16>(double         val,
 template <>
 inline bool isOnePacked<bf16>(uint8_t const* scaleBytes,
                               uint8_t const* dataBytes,
-                              size_t         scaleIndex,
-                              size_t         dataIndex)
+                              index_t         scaleIndex,
+                              index_t         dataIndex)
 {
 
     return isOne<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
@@ -188,8 +188,8 @@ inline bool isOnePacked<bf16>(uint8_t const* scaleBytes,
 template <>
 inline bool isZeroPacked<bf16>(uint8_t const* scaleBytes,
                                uint8_t const* dataBytes,
-                               size_t         scaleIndex,
-                               size_t         dataIndex)
+                               index_t         scaleIndex,
+                               index_t         dataIndex)
 {
     return isZero<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -198,8 +198,8 @@ inline bool isZeroPacked<bf16>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<bf16>(uint8_t const* scaleBytes,
                               uint8_t const* dataBytes,
-                              size_t         scaleIndex,
-                              size_t         dataIndex)
+                              index_t         scaleIndex,
+                              index_t         dataIndex)
 {
     return isNaN<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -207,8 +207,8 @@ inline bool isNaNPacked<bf16>(uint8_t const* scaleBytes,
 template <>
 inline bool isInfPacked<bf16>(uint8_t const* scaleBytes,
                               uint8_t const* dataBytes,
-                              size_t         scaleIndex,
-                              size_t         dataIndex)
+                              index_t         scaleIndex,
+                              index_t         dataIndex)
 {
     return isInf<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -218,8 +218,8 @@ template <>
 inline bool isLessPacked<bf16>(double         val,
                                uint8_t const* scaleBytes,
                                uint8_t const* dataBytes,
-                               size_t         scaleIndex,
-                               size_t         dataIndex)
+                               index_t         scaleIndex,
+                               index_t         dataIndex)
 {
     return isLess<bf16>(val, scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -229,21 +229,21 @@ template <>
 inline bool isGreaterPacked<bf16>(double         val,
                                   uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes,
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex)
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex)
 {
     return isGreater<bf16>(val, scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
 
 template <>
-inline bool isSubnorm<bf16>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<bf16>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint16_t data = getDataFP16(dataBytes, dataIndex);
     return isSubNormal<uint16_t>(data, bf16::dataInfo.mantissaBits, bf16::dataInfo.exponentBits);
 }
 
 template <>
-inline bool isSubnormPacked<bf16>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<bf16>(uint8_t const* dataBytes, index_t dataIndex)
 {
     return isSubnorm<bf16>(dataBytes, dataIndex);
 }
@@ -252,8 +252,8 @@ inline bool isSubnormPacked<bf16>(uint8_t const* dataBytes, size_t dataIndex)
 template <>
 inline double toDoublePacked<bf16>(uint8_t const* scaleBytes,
                                    uint8_t const* dataBytes,
-                                   size_t         scaleIndex,
-                                   size_t         dataIndex)
+                                   index_t         scaleIndex,
+                                   index_t         dataIndex)
 {
     return toDouble<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -261,8 +261,8 @@ inline double toDoublePacked<bf16>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<bf16>(uint8_t const* scaleBytes,
                                  uint8_t const* dataBytes,
-                                 size_t         scaleIndex,
-                                 size_t         dataIndex)
+                                 index_t         scaleIndex,
+                                 index_t         dataIndex)
 {
     return toFloat<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -271,8 +271,8 @@ inline float toFloatPacked<bf16>(uint8_t const* scaleBytes,
 template <>
 inline void setOne<bf16>(uint8_t* scaleBytes [[maybe_unused]],
                          uint8_t* dataBytes,
-                         size_t   scaleIndex [[maybe_unused]],
-                         size_t   dataIndex,
+                         index_t   scaleIndex [[maybe_unused]],
+                         index_t   dataIndex,
                          bool     subNormal [[maybe_unused]])
 {
     setDataFP16(dataBytes, dataIndex, bf16::oneMask);
@@ -282,8 +282,8 @@ inline void setOne<bf16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setZero<bf16>(uint8_t* scaleBytes [[maybe_unused]],
                           uint8_t* dataBytes,
-                          size_t   scaleIndex [[maybe_unused]],
-                          size_t   dataIndex)
+                          index_t   scaleIndex [[maybe_unused]],
+                          index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, bf16::positiveZeroMask);
 }
@@ -291,8 +291,8 @@ inline void setZero<bf16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<bf16>(uint8_t* scaleBytes [[maybe_unused]],
                          uint8_t* dataBytes,
-                         size_t   scaleIndex [[maybe_unused]],
-                         size_t   dataIndex)
+                         index_t   scaleIndex [[maybe_unused]],
+                         index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, bf16::dataNanMask);
 }
@@ -300,15 +300,15 @@ inline void setNaN<bf16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInf<bf16>(uint8_t* scaleBytes [[maybe_unused]],
                          uint8_t* dataBytes,
-                         size_t   scaleIndex [[maybe_unused]],
-                         size_t   dataIndex)
+                         index_t   scaleIndex [[maybe_unused]],
+                         index_t   dataIndex)
 {
 
     setDataFP16(dataBytes, dataIndex, bf16::dataInfMask);
 }
 
 template <>
-inline void setDataMax<bf16>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+inline void setDataMax<bf16>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         setDataFP16(dataBytes,
@@ -325,8 +325,8 @@ inline void setDataMax<bf16>(uint8_t* dataBytes, size_t dataIndex, bool subNorma
 template <>
 inline void setOnePacked<bf16>(uint8_t* scaleBytes,
                                uint8_t* dataBytes,
-                               size_t   scaleIndex,
-                               size_t   dataIndex,
+                               index_t   scaleIndex,
+                               index_t   dataIndex,
                                bool     subNormal [[maybe_unused]])
 {
     setOne<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
@@ -336,8 +336,8 @@ inline void setOnePacked<bf16>(uint8_t* scaleBytes,
 template <>
 inline void setZeroPacked<bf16>(uint8_t* scaleBytes,
                                 uint8_t* dataBytes,
-                                size_t   scaleIndex,
-                                size_t   dataIndex)
+                                index_t   scaleIndex,
+                                index_t   dataIndex)
 {
     setZero<bf16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -345,8 +345,8 @@ inline void setZeroPacked<bf16>(uint8_t* scaleBytes,
 template <>
 inline void setNaNPacked<bf16>(uint8_t* scaleBytes [[maybe_unused]],
                                uint8_t* dataBytes,
-                               size_t   scaleIndex [[maybe_unused]],
-                               size_t   dataIndex)
+                               index_t   scaleIndex [[maybe_unused]],
+                               index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, bf16::dataNanMask);
 }
@@ -354,15 +354,15 @@ inline void setNaNPacked<bf16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInfPacked<bf16>(uint8_t* scaleBytes [[maybe_unused]],
                                uint8_t* dataBytes,
-                               size_t   scaleIndex [[maybe_unused]],
-                               size_t   dataIndex)
+                               index_t   scaleIndex [[maybe_unused]],
+                               index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, bf16::dataInfMask);
 }
 
 template <>
 inline void
-    setDataMaxPacked<bf16>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMaxPacked<bf16>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     setDataMax<bf16>(dataBytes, dataIndex, subNormal, positive);
 }

--- a/lib/include/dataTypeInfo.hpp
+++ b/lib/include/dataTypeInfo.hpp
@@ -39,6 +39,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include <data_generation_utils.hpp>
+
 #if defined(__clang__)
 #include <type_traits>
 namespace my_math
@@ -206,8 +208,8 @@ namespace DGen
     template <typename DTYPE>
     inline bool isOne(uint8_t const* scaleBytes,
                       uint8_t const* dataBytes,
-                      size_t         scaleIndex,
-                      size_t         dataIndex);
+                      index_t         scaleIndex,
+                      index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -235,8 +237,8 @@ namespace DGen
     template <typename DTYPE>
     inline bool isZero(uint8_t const* scaleBytes,
                        uint8_t const* dataBytes,
-                       size_t         scaleIndex,
-                       size_t         dataIndex);
+                       index_t         scaleIndex,
+                       index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -264,8 +266,8 @@ namespace DGen
     template <typename DTYPE>
     inline bool isNaN(uint8_t const* scaleBytes,
                       uint8_t const* dataBytes,
-                      size_t         scaleIndex,
-                      size_t         dataIndex);
+                      index_t         scaleIndex,
+                      index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -293,20 +295,20 @@ namespace DGen
     template <typename DTYPE>
     inline bool isInf(uint8_t const* scaleBytes,
                       uint8_t const* dataBytes,
-                      size_t         scaleIndex,
-                      size_t         dataIndex);
+                      index_t         scaleIndex,
+                      index_t         dataIndex);
 
     /**
      * XXX
      */
     template <typename DTYPE>
-    inline bool isSubnorm(uint8_t const* dataBytes, size_t dataIndex);
+    inline bool isSubnorm(uint8_t const* dataBytes, index_t dataIndex);
 
     /**
      * XXX
      */
     template <typename DTYPE>
-    inline bool isSubnormPacked(uint8_t const* dataBytes, size_t dataIndex);
+    inline bool isSubnormPacked(uint8_t const* dataBytes, index_t dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -339,8 +341,8 @@ namespace DGen
     inline bool isLess(double         val,
                        uint8_t const* scaleBytes,
                        uint8_t const* dataBytes,
-                       size_t         scaleIndex,
-                       size_t         dataIndex);
+                       index_t         scaleIndex,
+                       index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -373,8 +375,8 @@ namespace DGen
     inline bool isGreater(double         val,
                           uint8_t const* scaleBytes,
                           uint8_t const* dataBytes,
-                          size_t         scaleIndex,
-                          size_t         dataIndex);
+                          index_t         scaleIndex,
+                          index_t         dataIndex);
 
     /**
      * Convert the product of the scale and data
@@ -403,8 +405,8 @@ namespace DGen
     template <typename DTYPE>
     inline double toDouble(uint8_t const* scaleBytes,
                            uint8_t const* dataBytes,
-                           size_t         scaleIndex,
-                           size_t         dataIndex);
+                           index_t         scaleIndex,
+                           index_t         dataIndex);
 
     /**
      * Convert the product of the scale and data
@@ -433,8 +435,8 @@ namespace DGen
     template <typename DTYPE>
     inline float toFloat(uint8_t const* scaleBytes,
                          uint8_t const* dataBytes,
-                         size_t         scaleIndex,
-                         size_t         dataIndex);
+                         index_t         scaleIndex,
+                         index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -463,8 +465,8 @@ namespace DGen
     template <typename DTYPE>
     inline bool isOnePacked(uint8_t const* scaleBytes,
                             uint8_t const* dataBytes,
-                            size_t         scaleIndex,
-                            size_t         dataIndex);
+                            index_t         scaleIndex,
+                            index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -492,8 +494,8 @@ namespace DGen
     template <typename DTYPE>
     inline bool isZeroPacked(uint8_t const* scaleBytes,
                              uint8_t const* dataBytes,
-                             size_t         scaleIndex,
-                             size_t         dataIndex);
+                             index_t         scaleIndex,
+                             index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -521,8 +523,8 @@ namespace DGen
     template <typename DTYPE>
     inline bool isNaNPacked(uint8_t const* scaleBytes,
                             uint8_t const* dataBytes,
-                            size_t         scaleIndex,
-                            size_t         dataIndex);
+                            index_t         scaleIndex,
+                            index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -550,8 +552,8 @@ namespace DGen
     template <typename DTYPE>
     inline bool isInfPacked(uint8_t const* scaleBytes,
                             uint8_t const* dataBytes,
-                            size_t         scaleIndex,
-                            size_t         dataIndex);
+                            index_t         scaleIndex,
+                            index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -584,8 +586,8 @@ namespace DGen
     inline bool isLessPacked(double         val,
                              uint8_t const* scaleBytes,
                              uint8_t const* dataBytes,
-                             size_t         scaleIndex,
-                             size_t         dataIndex);
+                             index_t         scaleIndex,
+                             index_t         dataIndex);
 
     /**
      * Check if the product of the scale and data
@@ -618,8 +620,8 @@ namespace DGen
     inline bool isGreaterPacked(double         val,
                                 uint8_t const* scaleBytes,
                                 uint8_t const* dataBytes,
-                                size_t         scaleIndex,
-                                size_t         dataIndex);
+                                index_t         scaleIndex,
+                                index_t         dataIndex);
 
     /**
      * Convert the product of the scale and data
@@ -648,8 +650,8 @@ namespace DGen
     template <typename DTYPE>
     inline double toDoublePacked(uint8_t const* scaleBytes,
                                  uint8_t const* dataBytes,
-                                 size_t         scaleIndex,
-                                 size_t         dataIndex);
+                                 index_t         scaleIndex,
+                                 index_t         dataIndex);
 
     /**
      * Convert the product of the scale and data
@@ -678,8 +680,8 @@ namespace DGen
     template <typename DTYPE>
     inline float toFloatPacked(uint8_t const* scaleBytes,
                                uint8_t const* dataBytes,
-                               size_t         scaleIndex,
-                               size_t         dataIndex);
+                               index_t         scaleIndex,
+                               index_t         dataIndex);
 
     /**
      * Set the product of the scale and data to be 1
@@ -707,8 +709,8 @@ namespace DGen
     template <typename DTYPE>
     void setOne(uint8_t* scaleBytes,
                 uint8_t* dataBytes,
-                size_t   scaleIndex,
-                size_t   dataIndex,
+                index_t   scaleIndex,
+                index_t   dataIndex,
                 bool     subNormal = false);
 
     /**
@@ -731,7 +733,7 @@ namespace DGen
      *      The index to the data bit representation
      */
     template <typename DTYPE>
-    void setZero(uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex);
+    void setZero(uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex);
 
     /**
      * Set the product of the scale and data to be NaN,
@@ -753,7 +755,7 @@ namespace DGen
      *      The index to the data bit representation
      */
     template <typename DTYPE>
-    void setNaN(uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex);
+    void setNaN(uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex);
 
     /**
      * Set the product of the scale and data to be Inf,
@@ -775,7 +777,7 @@ namespace DGen
      *      The index to the data bit representation
      */
     template <typename DTYPE>
-    void setInf(uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex);
+    void setInf(uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex);
 
     /**
      * Set the element at the specified index
@@ -801,7 +803,7 @@ namespace DGen
      */
     template <typename DTYPE>
     void setDataMax(uint8_t* dataBytes,
-                    size_t   dataIndex,
+                    index_t   dataIndex,
                     bool     subNormal = false,
                     bool     positive  = true);
 
@@ -831,8 +833,8 @@ namespace DGen
     template <typename DTYPE>
     void setOnePacked(uint8_t* scaleBytes,
                       uint8_t* dataBytes,
-                      size_t   scaleIndex,
-                      size_t   dataIndex,
+                      index_t   scaleIndex,
+                      index_t   dataIndex,
                       bool     subNormal = false);
 
     /**
@@ -856,7 +858,7 @@ namespace DGen
      */
     template <typename DTYPE>
     void
-        setZeroPacked(uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex);
+        setZeroPacked(uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex);
 
     /**
      * Set the product of the scale and data to be NaN,
@@ -878,7 +880,7 @@ namespace DGen
      *      The index to the data bit representation
      */
     template <typename DTYPE>
-    void setNaNPacked(uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex);
+    void setNaNPacked(uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex);
 
     /**
      * Set the product of the scale and data to be Inf,
@@ -900,7 +902,7 @@ namespace DGen
      *      The index to the data bit representation
      */
     template <typename DTYPE>
-    void setInfPacked(uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex);
+    void setInfPacked(uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex);
 
     /**
      * Set the element at the specified index
@@ -926,7 +928,7 @@ namespace DGen
      */
     template <typename DTYPE>
     void setDataMaxPacked(uint8_t* dataBytes,
-                          size_t   dataIndex,
+                          index_t   dataIndex,
                           bool     subNormal = false,
                           bool     positive  = true);
 

--- a/lib/include/dataTypeInfo_impl.hpp
+++ b/lib/include/dataTypeInfo_impl.hpp
@@ -32,7 +32,7 @@
 
 template <typename DTYPE>
 inline bool
-    isOne(uint8_t const* scaleBytes, uint8_t const* dataBytes, size_t scaleIndex, size_t dataIndex)
+    isOne(uint8_t const* scaleBytes, uint8_t const* dataBytes, index_t scaleIndex, index_t dataIndex)
 {
     return toDouble<DTYPE>(scaleBytes, dataBytes, scaleIndex, dataIndex) == 1.0;
 }
@@ -40,8 +40,8 @@ inline bool
 template <typename DTYPE>
 inline bool isOnePacked(uint8_t const* scaleBytes,
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex,
-                        size_t         dataIndex)
+                        index_t         scaleIndex,
+                        index_t         dataIndex)
 {
 
     return toDoublePacked<DTYPE>(scaleBytes, dataBytes, scaleIndex, dataIndex) == 1.0;
@@ -51,8 +51,8 @@ template <typename DTYPE>
 inline bool isLess(double         val,
                    uint8_t const* scaleBytes,
                    uint8_t const* dataBytes,
-                   size_t         scaleIndex,
-                   size_t         dataIndex)
+                   index_t         scaleIndex,
+                   index_t         dataIndex)
 {
     return toDouble<DTYPE>(scaleBytes, dataBytes, scaleIndex, dataIndex) < val;
 }
@@ -61,8 +61,8 @@ template <typename DTYPE>
 inline bool isLessPacked(double         val,
                          uint8_t const* scaleBytes,
                          uint8_t const* dataBytes,
-                         size_t         scaleIndex,
-                         size_t         dataIndex)
+                         index_t         scaleIndex,
+                         index_t         dataIndex)
 {
     return toDoublePacked<DTYPE>(scaleBytes, dataBytes, scaleIndex, dataIndex) < val;
 }
@@ -71,8 +71,8 @@ template <typename DTYPE>
 inline bool isGreater(double         val,
                       uint8_t const* scaleBytes,
                       uint8_t const* dataBytes,
-                      size_t         scaleIndex,
-                      size_t         dataIndex)
+                      index_t         scaleIndex,
+                      index_t         dataIndex)
 {
     return toDouble<DTYPE>(scaleBytes, dataBytes, scaleIndex, dataIndex) > val;
 }
@@ -81,8 +81,8 @@ template <typename DTYPE>
 inline bool isGreaterPacked(double         val,
                             uint8_t const* scaleBytes,
                             uint8_t const* dataBytes,
-                            size_t         scaleIndex,
-                            size_t         dataIndex)
+                            index_t         scaleIndex,
+                            index_t         dataIndex)
 {
     return toDoublePacked<DTYPE>(scaleBytes, dataBytes, scaleIndex, dataIndex) > val;
 }

--- a/lib/include/data_generation_utils.hpp
+++ b/lib/include/data_generation_utils.hpp
@@ -26,12 +26,14 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <tuple>
 #include <vector>
 
 namespace DGen
 {
+    typedef uint64_t index_t;
 
     template <typename CartesianProductVectorType, typename... Ts>
     auto cartesian_product_helper(CartesianProductVectorType& vec, std::tuple<Ts...> t)
@@ -61,8 +63,8 @@ namespace DGen
 
     struct dimension_iterator
     {
-        const std::vector<int> dimensions;
-        explicit dimension_iterator(std::vector<int> const& dim)
+        const std::vector<index_t> dimensions;
+        explicit dimension_iterator(std::vector<index_t> const& dim)
             : dimensions(dim)
         {
         }
@@ -70,12 +72,12 @@ namespace DGen
         struct iterator
         {
         private:
-            const std::vector<int> dimensions;
-            std::vector<int>       current;
-            std::vector<int>*      curr_ptr;
+            const std::vector<index_t> dimensions;
+            std::vector<index_t>       current;
+            std::vector<index_t>*      curr_ptr;
 
         public:
-            explicit iterator(std::vector<int> const& dim)
+            explicit iterator(std::vector<index_t> const& dim)
                 : dimensions(dim)
                 , current(dim.size(), 0)
                 , curr_ptr(&current)
@@ -98,11 +100,11 @@ namespace DGen
                 std::cout << "\n";
             }
 
-            const std::vector<int>& operator*() const
+            const std::vector<index_t>& operator*() const
             {
                 return *curr_ptr;
             }
-            const std::vector<int>* operator->()
+            const std::vector<index_t>* operator->()
             {
                 return curr_ptr;
             }
@@ -159,9 +161,9 @@ namespace DGen
         }
     };
 
-    inline int get_strided_idx(const std::vector<int>& indices, const std::vector<int>& stride)
+    inline index_t get_strided_idx(const std::vector<index_t>& indices, const std::vector<index_t>& stride)
     {
-        int res = 0;
+        index_t res = 0;
         for(size_t i = 0; i < indices.size(); i++)
         {
             res += indices[i] * stride[i];

--- a/lib/include/f32_impl.hpp
+++ b/lib/include/f32_impl.hpp
@@ -28,9 +28,9 @@
 #include "dataTypeInfo.hpp"
 #include "f32.hpp"
 
-inline uint getDataF32(const uint8_t* dataBytes, size_t index)
+inline uint getDataF32(const uint8_t* dataBytes, index_t index)
 {
-    size_t cellIndex = index * 4;
+    index_t cellIndex = index * 4;
 
     uint _1_8   = *(dataBytes + cellIndex);
     uint _9_16  = *(dataBytes + cellIndex + 1);
@@ -40,9 +40,9 @@ inline uint getDataF32(const uint8_t* dataBytes, size_t index)
     return (_25_32 << 24) | (_17_24 << 16) | (_9_16 << 8) | _1_8;
 }
 
-inline void setDataF32(uint8_t* dataBytes, size_t index, uint mask)
+inline void setDataF32(uint8_t* dataBytes, index_t index, uint mask)
 {
-    size_t cellIndex = index * 4;
+    index_t cellIndex = index * 4;
 
     uint _1_8   = mask & 0xff;
     uint _9_16  = (mask >> 8) & 0xff;
@@ -59,8 +59,8 @@ inline void setDataF32(uint8_t* dataBytes, size_t index, uint mask)
 template <>
 inline bool isOne<f32>(uint8_t const* scaleBytes [[maybe_unused]],
                        uint8_t const* dataBytes,
-                       size_t         scaleIndex [[maybe_unused]],
-                       size_t         dataIndex)
+                       index_t         scaleIndex [[maybe_unused]],
+                       index_t         dataIndex)
 {
     uint bRep = getDataF32(dataBytes, dataIndex);
 
@@ -74,8 +74,8 @@ inline bool isOne<f32>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isNaN<f32>(uint8_t const* scaleBytes [[maybe_unused]],
                        uint8_t const* dataBytes,
-                       size_t         scaleIndex [[maybe_unused]],
-                       size_t         dataIndex)
+                       index_t         scaleIndex [[maybe_unused]],
+                       index_t         dataIndex)
 {
     uint bRep = getDataF32(dataBytes, dataIndex);
 
@@ -89,8 +89,8 @@ inline bool isNaN<f32>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isZero<f32>(uint8_t const* scaleBytes,
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex,
-                        size_t         dataIndex)
+                        index_t         scaleIndex,
+                        index_t         dataIndex)
 {
 
     if(isNaN<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex))
@@ -107,8 +107,8 @@ inline bool isZero<f32>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<f32>(uint8_t const* scaleBytes [[maybe_unused]],
                        uint8_t const* dataBytes,
-                       size_t         scaleIndex [[maybe_unused]],
-                       size_t         dataIndex)
+                       index_t         scaleIndex [[maybe_unused]],
+                       index_t         dataIndex)
 {
     uint bRep = getDataF32(dataBytes, dataIndex);
 
@@ -123,8 +123,8 @@ template <>
 inline bool isLess<f32>(double         val,
                         uint8_t const* scaleBytes [[maybe_unused]],
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex [[maybe_unused]],
-                        size_t         dataIndex)
+                        index_t         scaleIndex [[maybe_unused]],
+                        index_t         dataIndex)
 {
     uint bRep = getDataF32(dataBytes, dataIndex);
 
@@ -139,8 +139,8 @@ template <>
 inline bool isGreater<f32>(double         val,
                            uint8_t const* scaleBytes [[maybe_unused]],
                            uint8_t const* dataBytes,
-                           size_t         scaleIndex [[maybe_unused]],
-                           size_t         dataIndex)
+                           index_t         scaleIndex [[maybe_unused]],
+                           index_t         dataIndex)
 {
     uint bRep = getDataF32(dataBytes, dataIndex);
 
@@ -154,8 +154,8 @@ inline bool isGreater<f32>(double         val,
 template <>
 inline double toDouble<f32>(uint8_t const* scaleBytes [[maybe_unused]],
                             uint8_t const* dataBytes,
-                            size_t         scaleIndex [[maybe_unused]],
-                            size_t         dataIndex)
+                            index_t         scaleIndex [[maybe_unused]],
+                            index_t         dataIndex)
 {
     uint bRep = getDataF32(dataBytes, dataIndex);
 
@@ -168,8 +168,8 @@ inline double toDouble<f32>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline float toFloat<f32>(uint8_t const* scaleBytes [[maybe_unused]],
                           uint8_t const* dataBytes,
-                          size_t         scaleIndex [[maybe_unused]],
-                          size_t         dataIndex)
+                          index_t         scaleIndex [[maybe_unused]],
+                          index_t         dataIndex)
 {
     uint bRep = getDataF32(dataBytes, dataIndex);
 
@@ -183,8 +183,8 @@ inline float toFloat<f32>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isOnePacked<f32>(uint8_t const* scaleBytes,
                              uint8_t const* dataBytes,
-                             size_t         scaleIndex,
-                             size_t         dataIndex)
+                             index_t         scaleIndex,
+                             index_t         dataIndex)
 {
 
     return isOne<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
@@ -194,8 +194,8 @@ inline bool isOnePacked<f32>(uint8_t const* scaleBytes,
 template <>
 inline bool isZeroPacked<f32>(uint8_t const* scaleBytes,
                               uint8_t const* dataBytes,
-                              size_t         scaleIndex,
-                              size_t         dataIndex)
+                              index_t         scaleIndex,
+                              index_t         dataIndex)
 {
     return isZero<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -204,8 +204,8 @@ inline bool isZeroPacked<f32>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<f32>(uint8_t const* scaleBytes,
                              uint8_t const* dataBytes,
-                             size_t         scaleIndex,
-                             size_t         dataIndex)
+                             index_t         scaleIndex,
+                             index_t         dataIndex)
 {
     return isNaN<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -213,8 +213,8 @@ inline bool isNaNPacked<f32>(uint8_t const* scaleBytes,
 template <>
 inline bool isInfPacked<f32>(uint8_t const* scaleBytes,
                              uint8_t const* dataBytes,
-                             size_t         scaleIndex,
-                             size_t         dataIndex)
+                             index_t         scaleIndex,
+                             index_t         dataIndex)
 {
     return isInf<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -224,8 +224,8 @@ template <>
 inline bool isLessPacked<f32>(double         val,
                               uint8_t const* scaleBytes,
                               uint8_t const* dataBytes,
-                              size_t         scaleIndex,
-                              size_t         dataIndex)
+                              index_t         scaleIndex,
+                              index_t         dataIndex)
 {
     return isLess<f32>(val, scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -235,21 +235,21 @@ template <>
 inline bool isGreaterPacked<f32>(double         val,
                                  uint8_t const* scaleBytes,
                                  uint8_t const* dataBytes,
-                                 size_t         scaleIndex,
-                                 size_t         dataIndex)
+                                 index_t         scaleIndex,
+                                 index_t         dataIndex)
 {
     return isGreater<f32>(val, scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
 
 template <>
-inline bool isSubnorm<f32>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<f32>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint data = getDataF32(dataBytes, dataIndex);
     return isSubNormal<uint>(data, f32::dataInfo.mantissaBits, f32::dataInfo.exponentBits);
 }
 
 template <>
-inline bool isSubnormPacked<f32>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<f32>(uint8_t const* dataBytes, index_t dataIndex)
 {
     return isSubnorm<f32>(dataBytes, dataIndex);
 }
@@ -258,8 +258,8 @@ inline bool isSubnormPacked<f32>(uint8_t const* dataBytes, size_t dataIndex)
 template <>
 inline double toDoublePacked<f32>(uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes,
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex)
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex)
 {
     return toDouble<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -267,8 +267,8 @@ inline double toDoublePacked<f32>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<f32>(uint8_t const* scaleBytes,
                                 uint8_t const* dataBytes,
-                                size_t         scaleIndex,
-                                size_t         dataIndex)
+                                index_t         scaleIndex,
+                                index_t         dataIndex)
 {
     return toFloat<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -277,8 +277,8 @@ inline float toFloatPacked<f32>(uint8_t const* scaleBytes,
 template <>
 inline void setOne<f32>(uint8_t* scaleBytes [[maybe_unused]],
                         uint8_t* dataBytes,
-                        size_t   scaleIndex [[maybe_unused]],
-                        size_t   dataIndex,
+                        index_t   scaleIndex [[maybe_unused]],
+                        index_t   dataIndex,
                         bool     subNormal [[maybe_unused]])
 {
     setDataF32(dataBytes, dataIndex, f32::oneMask);
@@ -288,8 +288,8 @@ inline void setOne<f32>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setZero<f32>(uint8_t* scaleBytes [[maybe_unused]],
                          uint8_t* dataBytes,
-                         size_t   scaleIndex [[maybe_unused]],
-                         size_t   dataIndex)
+                         index_t   scaleIndex [[maybe_unused]],
+                         index_t   dataIndex)
 {
     setDataF32(dataBytes, dataIndex, f32::positiveZeroMask);
 }
@@ -297,8 +297,8 @@ inline void setZero<f32>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<f32>(uint8_t* scaleBytes [[maybe_unused]],
                         uint8_t* dataBytes,
-                        size_t   scaleIndex [[maybe_unused]],
-                        size_t   dataIndex)
+                        index_t   scaleIndex [[maybe_unused]],
+                        index_t   dataIndex)
 {
     setDataF32(dataBytes, dataIndex, f32::dataNanMask);
 }
@@ -306,15 +306,15 @@ inline void setNaN<f32>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInf<f32>(uint8_t* scaleBytes [[maybe_unused]],
                         uint8_t* dataBytes,
-                        size_t   scaleIndex [[maybe_unused]],
-                        size_t   dataIndex)
+                        index_t   scaleIndex [[maybe_unused]],
+                        index_t   dataIndex)
 {
 
     setDataF32(dataBytes, dataIndex, f32::dataInfMask);
 }
 
 template <>
-inline void setDataMax<f32>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+inline void setDataMax<f32>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         setDataF32(dataBytes,
@@ -331,8 +331,8 @@ inline void setDataMax<f32>(uint8_t* dataBytes, size_t dataIndex, bool subNormal
 template <>
 inline void setOnePacked<f32>(uint8_t* scaleBytes,
                               uint8_t* dataBytes,
-                              size_t   scaleIndex,
-                              size_t   dataIndex,
+                              index_t   scaleIndex,
+                              index_t   dataIndex,
                               bool     subNormal [[maybe_unused]])
 {
     setOne<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
@@ -341,7 +341,7 @@ inline void setOnePacked<f32>(uint8_t* scaleBytes,
 //set XN = 0, scale X will not be changed
 template <>
 inline void
-    setZeroPacked<f32>(uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex)
+    setZeroPacked<f32>(uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex)
 {
     setZero<f32>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -349,8 +349,8 @@ inline void
 template <>
 inline void setNaNPacked<f32>(uint8_t* scaleBytes [[maybe_unused]],
                               uint8_t* dataBytes,
-                              size_t   scaleIndex [[maybe_unused]],
-                              size_t   dataIndex)
+                              index_t   scaleIndex [[maybe_unused]],
+                              index_t   dataIndex)
 {
     setDataF32(dataBytes, dataIndex, f32::dataNanMask);
 }
@@ -358,15 +358,15 @@ inline void setNaNPacked<f32>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInfPacked<f32>(uint8_t* scaleBytes [[maybe_unused]],
                               uint8_t* dataBytes,
-                              size_t   scaleIndex [[maybe_unused]],
-                              size_t   dataIndex)
+                              index_t   scaleIndex [[maybe_unused]],
+                              index_t   dataIndex)
 {
     setDataF32(dataBytes, dataIndex, f32::dataInfMask);
 }
 
 template <>
 inline void
-    setDataMaxPacked<f32>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMaxPacked<f32>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     setDataMax<f32>(dataBytes, dataIndex, subNormal, positive);
 }

--- a/lib/include/fp16_impl.hpp
+++ b/lib/include/fp16_impl.hpp
@@ -32,8 +32,8 @@
 template <>
 inline bool isNaN<fp16>(uint8_t const* scaleBytes [[maybe_unused]],
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex [[maybe_unused]],
-                        size_t         dataIndex)
+                        index_t         scaleIndex [[maybe_unused]],
+                        index_t         dataIndex)
 {
     uint16_t data = getDataFP16(dataBytes, dataIndex);
 
@@ -47,8 +47,8 @@ inline bool isNaN<fp16>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isZero<fp16>(uint8_t const* scaleBytes,
                          uint8_t const* dataBytes,
-                         size_t         scaleIndex,
-                         size_t         dataIndex)
+                         index_t         scaleIndex,
+                         index_t         dataIndex)
 {
 
     if(isNaN<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex))
@@ -62,8 +62,8 @@ inline bool isZero<fp16>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<fp16>(uint8_t const* scaleBytes [[maybe_unused]],
                         uint8_t const* dataBytes,
-                        size_t         scaleIndex [[maybe_unused]],
-                        size_t         dataIndex)
+                        index_t         scaleIndex [[maybe_unused]],
+                        index_t         dataIndex)
 {
     uint16_t data = getDataFP16(dataBytes, dataIndex);
     return (data & fp16::setSignMask) == fp16::dataInfMask;
@@ -73,8 +73,8 @@ inline bool isInf<fp16>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline double toDouble<fp16>(uint8_t const* scaleBytes,
                              uint8_t const* dataBytes,
-                             size_t         scaleIndex,
-                             size_t         dataIndex)
+                             index_t         scaleIndex,
+                             index_t         dataIndex)
 {
 
     if(isNaN<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex))
@@ -110,8 +110,8 @@ inline double toDouble<fp16>(uint8_t const* scaleBytes,
 template <>
 inline float toFloat<fp16>(uint8_t const* scaleBytes,
                            uint8_t const* dataBytes,
-                           size_t         scaleIndex,
-                           size_t         dataIndex)
+                           index_t         scaleIndex,
+                           index_t         dataIndex)
 {
     if(isNaN<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -146,8 +146,8 @@ inline float toFloat<fp16>(uint8_t const* scaleBytes,
 template <>
 inline bool isZeroPacked<fp16>(uint8_t const* scaleBytes,
                                uint8_t const* dataBytes,
-                               size_t         scaleIndex,
-                               size_t         dataIndex)
+                               index_t         scaleIndex,
+                               index_t         dataIndex)
 {
     return isZero<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -155,8 +155,8 @@ inline bool isZeroPacked<fp16>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<fp16>(uint8_t const* scaleBytes,
                               uint8_t const* dataBytes,
-                              size_t         scaleIndex,
-                              size_t         dataIndex)
+                              index_t         scaleIndex,
+                              index_t         dataIndex)
 {
     return isNaN<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -164,8 +164,8 @@ inline bool isNaNPacked<fp16>(uint8_t const* scaleBytes,
 template <>
 inline bool isInfPacked<fp16>(uint8_t const* scaleBytes,
                               uint8_t const* dataBytes,
-                              size_t         scaleIndex,
-                              size_t         dataIndex)
+                              index_t         scaleIndex,
+                              index_t         dataIndex)
 {
     return isInf<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -175,8 +175,8 @@ template <>
 inline bool isLessPacked<fp16>(double         val,
                                uint8_t const* scaleBytes,
                                uint8_t const* dataBytes,
-                               size_t         scaleIndex,
-                               size_t         dataIndex)
+                               index_t         scaleIndex,
+                               index_t         dataIndex)
 {
     return isLess<fp16>(val, scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -186,21 +186,21 @@ template <>
 inline bool isGreaterPacked<fp16>(double         val,
                                   uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes,
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex)
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex)
 {
     return isGreater<fp16>(val, scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
 
 template <>
-inline bool isSubnorm<fp16>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<fp16>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint16_t data = getDataFP16(dataBytes, dataIndex);
     return isSubNormal<uint16_t>(data, fp16::dataInfo.mantissaBits, fp16::dataInfo.exponentBits);
 }
 
 template <>
-inline bool isSubnormPacked<fp16>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<fp16>(uint8_t const* dataBytes, index_t dataIndex)
 {
     return isSubnorm<fp16>(dataBytes, dataIndex);
 }
@@ -209,8 +209,8 @@ inline bool isSubnormPacked<fp16>(uint8_t const* dataBytes, size_t dataIndex)
 template <>
 inline double toDoublePacked<fp16>(uint8_t const* scaleBytes,
                                    uint8_t const* dataBytes,
-                                   size_t         scaleIndex,
-                                   size_t         dataIndex)
+                                   index_t         scaleIndex,
+                                   index_t         dataIndex)
 {
     return toDouble<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -218,8 +218,8 @@ inline double toDoublePacked<fp16>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<fp16>(uint8_t const* scaleBytes,
                                  uint8_t const* dataBytes,
-                                 size_t         scaleIndex,
-                                 size_t         dataIndex)
+                                 index_t         scaleIndex,
+                                 index_t         dataIndex)
 {
     return toFloat<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -228,8 +228,8 @@ inline float toFloatPacked<fp16>(uint8_t const* scaleBytes,
 template <>
 inline void setOne<fp16>(uint8_t* scaleBytes [[maybe_unused]],
                          uint8_t* dataBytes,
-                         size_t   scaleIndex [[maybe_unused]],
-                         size_t   dataIndex,
+                         index_t   scaleIndex [[maybe_unused]],
+                         index_t   dataIndex,
                          bool     subNormal [[maybe_unused]])
 {
     setDataFP16(dataBytes, dataIndex, fp16::oneMask);
@@ -239,8 +239,8 @@ inline void setOne<fp16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setZero<fp16>(uint8_t* scaleBytes [[maybe_unused]],
                           uint8_t* dataBytes,
-                          size_t   scaleIndex [[maybe_unused]],
-                          size_t   dataIndex)
+                          index_t   scaleIndex [[maybe_unused]],
+                          index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, fp16::positiveZeroMask);
 }
@@ -248,8 +248,8 @@ inline void setZero<fp16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<fp16>(uint8_t* scaleBytes [[maybe_unused]],
                          uint8_t* dataBytes,
-                         size_t   scaleIndex [[maybe_unused]],
-                         size_t   dataIndex)
+                         index_t   scaleIndex [[maybe_unused]],
+                         index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, fp16::dataNanMask);
 }
@@ -257,15 +257,15 @@ inline void setNaN<fp16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInf<fp16>(uint8_t* scaleBytes [[maybe_unused]],
                          uint8_t* dataBytes,
-                         size_t   scaleIndex [[maybe_unused]],
-                         size_t   dataIndex)
+                         index_t   scaleIndex [[maybe_unused]],
+                         index_t   dataIndex)
 {
 
     setDataFP16(dataBytes, dataIndex, fp16::dataInfMask);
 }
 
 template <>
-inline void setDataMax<fp16>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+inline void setDataMax<fp16>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         setDataFP16(dataBytes,
@@ -282,8 +282,8 @@ inline void setDataMax<fp16>(uint8_t* dataBytes, size_t dataIndex, bool subNorma
 template <>
 inline void setOnePacked<fp16>(uint8_t* scaleBytes,
                                uint8_t* dataBytes,
-                               size_t   scaleIndex,
-                               size_t   dataIndex,
+                               index_t   scaleIndex,
+                               index_t   dataIndex,
                                bool     subNormal [[maybe_unused]])
 {
     setOne<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
@@ -293,8 +293,8 @@ inline void setOnePacked<fp16>(uint8_t* scaleBytes,
 template <>
 inline void setZeroPacked<fp16>(uint8_t* scaleBytes,
                                 uint8_t* dataBytes,
-                                size_t   scaleIndex,
-                                size_t   dataIndex)
+                                index_t   scaleIndex,
+                                index_t   dataIndex)
 {
     setZero<fp16>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -302,8 +302,8 @@ inline void setZeroPacked<fp16>(uint8_t* scaleBytes,
 template <>
 inline void setNaNPacked<fp16>(uint8_t* scaleBytes [[maybe_unused]],
                                uint8_t* dataBytes,
-                               size_t   scaleIndex [[maybe_unused]],
-                               size_t   dataIndex)
+                               index_t   scaleIndex [[maybe_unused]],
+                               index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, fp16::dataNanMask);
 }
@@ -311,15 +311,15 @@ inline void setNaNPacked<fp16>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInfPacked<fp16>(uint8_t* scaleBytes [[maybe_unused]],
                                uint8_t* dataBytes,
-                               size_t   scaleIndex [[maybe_unused]],
-                               size_t   dataIndex)
+                               index_t   scaleIndex [[maybe_unused]],
+                               index_t   dataIndex)
 {
     setDataFP16(dataBytes, dataIndex, fp16::dataInfMask);
 }
 
 template <>
 inline void
-    setDataMaxPacked<fp16>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMaxPacked<fp16>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     setDataMax<fp16>(dataBytes, dataIndex, subNormal, positive);
 }

--- a/lib/include/fp6.hpp
+++ b/lib/include/fp6.hpp
@@ -26,11 +26,11 @@
 
 #pragma once
 
-inline uint8_t getDataFromPackedF6(uint8_t const* dataBytes, int index)
+inline uint8_t getDataFromPackedF6(uint8_t const* dataBytes, index_t index)
 {
-    int cellIndex = (index / 4) * 3;
+    index_t cellIndex = (index / 4) * 3;
 
-    int rem = index % 4;
+    index_t rem = index % 4;
 
     uint8_t out = 0b0;
 
@@ -66,11 +66,11 @@ inline uint8_t getDataFromPackedF6(uint8_t const* dataBytes, int index)
     return out;
 }
 
-inline void setDataPackedF6(uint8_t* dataBytes, int index, uint8_t mask)
+inline void setDataPackedF6(uint8_t* dataBytes, size_t index, uint8_t mask)
 {
-    int cellIndex = (index / 4) * 3;
+    size_t cellIndex = (index / 4) * 3;
 
-    int rem = index % 4;
+    size_t rem = index % 4;
 
     uint8_t l = 0b0;
     uint8_t r = 0b0;

--- a/lib/include/ocp_e2m1_mxfp4_impl.hpp
+++ b/lib/include/ocp_e2m1_mxfp4_impl.hpp
@@ -38,9 +38,9 @@
  *      The index to the bit representation
  *      to read
  */
-static uint8_t getDataFromPackedF4(uint8_t const* dataBytes, int index)
+static uint8_t getDataFromPackedF4(uint8_t const* dataBytes, size_t index)
 {
-    int cellIndex = index / 2;
+    size_t cellIndex = index / 2;
 
     // odd index -> first half of cell
     if(index % 2)
@@ -65,9 +65,9 @@ static uint8_t getDataFromPackedF4(uint8_t const* dataBytes, int index)
  *      The mask to set the bit representation
  *      to
  */
-static void setDataPackedF4(uint8_t* dataBytes, int index, uint8_t mask)
+static void setDataPackedF4(uint8_t* dataBytes, size_t index, uint8_t mask)
 {
-    int cellIndex = index / 2;
+    size_t cellIndex = index / 2;
 
     // odd index -> first half of cell
     if(index % 2)
@@ -85,8 +85,8 @@ static void setDataPackedF4(uint8_t* dataBytes, int index, uint8_t mask)
 template <>
 inline bool isNaN<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes [[maybe_unused]],
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex [[maybe_unused]])
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex [[maybe_unused]])
 {
     // no need to check for data as it does not have representation
     uint8_t scale = *(scaleBytes + scaleIndex);
@@ -96,8 +96,8 @@ inline bool isNaN<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline bool isZero<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                    uint8_t const* dataBytes,
-                                   size_t         scaleIndex,
-                                   size_t         dataIndex)
+                                   index_t         scaleIndex,
+                                   index_t         dataIndex)
 {
     if(isNaN<ocp_e2m1_mxfp4>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return false;
@@ -111,8 +111,8 @@ inline bool isZero<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline double toDouble<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                        uint8_t const* dataBytes,
-                                       size_t         scaleIndex,
-                                       size_t         dataIndex)
+                                       index_t         scaleIndex,
+                                       index_t         dataIndex)
 {
     if(isNaN<ocp_e2m1_mxfp4>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<double>::quiet_NaN();
@@ -132,8 +132,8 @@ inline double toDouble<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline float toFloat<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                      uint8_t const* dataBytes,
-                                     size_t         scaleIndex,
-                                     size_t         dataIndex)
+                                     index_t         scaleIndex,
+                                     index_t         dataIndex)
 {
     if(isNaN<ocp_e2m1_mxfp4>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -153,8 +153,8 @@ inline float toFloat<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                         uint8_t const* dataBytes [[maybe_unused]],
-                                        size_t         scaleIndex,
-                                        size_t         dataIndex [[maybe_unused]])
+                                        index_t         scaleIndex,
+                                        index_t         dataIndex [[maybe_unused]])
 {
     // no need to check for data as it does not have representation
     uint8_t scale = *(scaleBytes + scaleIndex);
@@ -164,8 +164,8 @@ inline bool isNaNPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline bool isInfPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes [[maybe_unused]],
                                         uint8_t const* dataBytes [[maybe_unused]],
-                                        size_t         scaleIndex [[maybe_unused]],
-                                        size_t         dataIndex [[maybe_unused]])
+                                        index_t         scaleIndex [[maybe_unused]],
+                                        index_t         dataIndex [[maybe_unused]])
 {
     // no infinity representation in ocp_e2m1_mxfp4 will always return false
     return false;
@@ -175,8 +175,8 @@ inline bool isInfPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes [[maybe_unused
 template <>
 inline bool isZeroPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                          uint8_t const* dataBytes,
-                                         size_t         scaleIndex,
-                                         size_t         dataIndex)
+                                         index_t         scaleIndex,
+                                         index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e2m1_mxfp4>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return false;
@@ -189,8 +189,8 @@ inline bool isZeroPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline double toDoublePacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                              uint8_t const* dataBytes,
-                                             size_t         scaleIndex,
-                                             size_t         dataIndex)
+                                             index_t         scaleIndex,
+                                             index_t         dataIndex)
 {
 
     if(isNaNPacked<ocp_e2m1_mxfp4>(scaleBytes, dataBytes, scaleIndex, dataIndex))
@@ -211,8 +211,8 @@ inline double toDoublePacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
                                            uint8_t const* dataBytes,
-                                           size_t         scaleIndex,
-                                           size_t         dataIndex)
+                                           index_t         scaleIndex,
+                                           index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e2m1_mxfp4>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -233,15 +233,15 @@ inline float toFloatPacked<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<ocp_e2m1_mxfp4>(uint8_t const* scaleBytes [[maybe_unused]],
                                   uint8_t const* dataBytes [[maybe_unused]],
-                                  size_t         scaleIndex [[maybe_unused]],
-                                  size_t         dataIndex [[maybe_unused]])
+                                  index_t         scaleIndex [[maybe_unused]],
+                                  index_t         dataIndex [[maybe_unused]])
 {
     // no inf representation for ocp_e2m1_mxfp4
     return false;
 }
 
 template <>
-inline bool isSubnorm<ocp_e2m1_mxfp4>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<ocp_e2m1_mxfp4>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint8_t data = *(dataBytes + dataIndex) & 0b00001111;
     return isSubNormal<uint16_t>(
@@ -249,7 +249,7 @@ inline bool isSubnorm<ocp_e2m1_mxfp4>(uint8_t const* dataBytes, size_t dataIndex
 }
 
 template <>
-inline bool isSubnormPacked<ocp_e2m1_mxfp4>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<ocp_e2m1_mxfp4>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint8_t data = getDataFromPackedF4(dataBytes, dataIndex);
     return isSubNormal<uint16_t>(
@@ -260,7 +260,7 @@ inline bool isSubnormPacked<ocp_e2m1_mxfp4>(uint8_t const* dataBytes, size_t dat
 //set XN = 1
 template <>
 inline void setOne<ocp_e2m1_mxfp4>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     *(scaleBytes + scaleIndex) = subNormal ? Constants::E8M0_2 : Constants::E8M0_1;
     *(dataBytes + dataIndex)
@@ -271,8 +271,8 @@ inline void setOne<ocp_e2m1_mxfp4>(
 template <>
 inline void setZero<ocp_e2m1_mxfp4>(uint8_t* scaleBytes [[maybe_unused]],
                                     uint8_t* dataBytes,
-                                    size_t   scaleIndex [[maybe_unused]],
-                                    size_t   dataIndex)
+                                    index_t   scaleIndex [[maybe_unused]],
+                                    index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = ocp_e2m1_mxfp4::positiveZeroMask;
 }
@@ -280,8 +280,8 @@ inline void setZero<ocp_e2m1_mxfp4>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<ocp_e2m1_mxfp4>(uint8_t* scaleBytes,
                                    uint8_t* dataBytes [[maybe_unused]],
-                                   size_t   scaleIndex,
-                                   size_t   dataIndex [[maybe_unused]])
+                                   index_t   scaleIndex,
+                                   index_t   dataIndex [[maybe_unused]])
 {
     *(scaleBytes + scaleIndex) = Constants::E8M0_NAN;
 }
@@ -290,15 +290,15 @@ inline void setNaN<ocp_e2m1_mxfp4>(uint8_t* scaleBytes,
 template <>
 inline void setInf<ocp_e2m1_mxfp4>(uint8_t* scaleBytes [[maybe_unused]],
                                    uint8_t* dataBytes [[maybe_unused]],
-                                   size_t   scaleIndex [[maybe_unused]],
-                                   size_t   dataIndex [[maybe_unused]])
+                                   index_t   scaleIndex [[maybe_unused]],
+                                   index_t   dataIndex [[maybe_unused]])
 {
     return;
 }
 
 template <>
 inline void
-    setDataMax<ocp_e2m1_mxfp4>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMax<ocp_e2m1_mxfp4>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         *(dataBytes + dataIndex) = positive ? ocp_e2m1_mxfp4::dataMaxPositiveSubNormalMask
@@ -310,7 +310,7 @@ inline void
 
 template <>
 inline void setDataMaxPacked<ocp_e2m1_mxfp4>(uint8_t* dataBytes,
-                                             size_t   dataIndex,
+                                             index_t   dataIndex,
                                              bool     subNormal,
                                              bool     positive)
 {
@@ -327,7 +327,7 @@ inline void setDataMaxPacked<ocp_e2m1_mxfp4>(uint8_t* dataBytes,
 
 template <>
 inline void setOnePacked<ocp_e2m1_mxfp4>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     *(scaleBytes + scaleIndex) = subNormal ? Constants::E8M0_2 : Constants::E8M0_1;
     uint8_t dataMask = subNormal ? ocp_e2m1_mxfp4::dataSubNormalOneMask : ocp_e2m1_mxfp4::oneMask;
@@ -339,8 +339,8 @@ inline void setOnePacked<ocp_e2m1_mxfp4>(
 template <>
 inline void setZeroPacked<ocp_e2m1_mxfp4>(uint8_t* scaleBytes [[maybe_unused]],
                                           uint8_t* dataBytes,
-                                          size_t   scaleIndex [[maybe_unused]],
-                                          size_t   dataIndex)
+                                          index_t   scaleIndex [[maybe_unused]],
+                                          index_t   dataIndex)
 {
     setDataPackedF4(dataBytes, dataIndex, ocp_e2m1_mxfp4::positiveZeroMask);
 }
@@ -348,8 +348,8 @@ inline void setZeroPacked<ocp_e2m1_mxfp4>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaNPacked<ocp_e2m1_mxfp4>(uint8_t* scaleBytes,
                                          uint8_t* dataBytes [[maybe_unused]],
-                                         size_t   scaleIndex,
-                                         size_t   dataIndex [[maybe_unused]])
+                                         index_t   scaleIndex,
+                                         index_t   dataIndex [[maybe_unused]])
 {
     *(scaleBytes + scaleIndex) = Constants::E8M0_NAN;
 }

--- a/lib/include/ocp_e2m3_mxfp6_impl.hpp
+++ b/lib/include/ocp_e2m3_mxfp6_impl.hpp
@@ -97,8 +97,8 @@ inline uint8_t scaleOne<ocp_e2m3_mxfp6>()
 template <>
 inline bool isNaN<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes [[maybe_unused]],
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex [[maybe_unused]])
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex [[maybe_unused]])
 {
     // no need to check for NAN in dataBytes since there's no NAN representation
     return *(scaleBytes + scaleIndex) == Constants::E8M0_NAN;
@@ -107,8 +107,8 @@ inline bool isNaN<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                         uint8_t const* dataBytes,
-                                        size_t         scaleIndex,
-                                        size_t         dataIndex)
+                                        index_t         scaleIndex,
+                                        index_t         dataIndex)
 {
     // since the scale is e8m0 and is 8 bits its packed is the same as unpacked
     // as well as there are no NAN for ocp_e3m2_mxfp6
@@ -118,8 +118,8 @@ inline bool isNaNPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes [[maybe_unused]],
                                   uint8_t const* dataBytes [[maybe_unused]],
-                                  size_t         scaleIndex [[maybe_unused]],
-                                  size_t         dataIndex [[maybe_unused]])
+                                  index_t         scaleIndex [[maybe_unused]],
+                                  index_t         dataIndex [[maybe_unused]])
 {
     // no infinity representation in ocp_e3m2_mxfp6 will always return false
     return false;
@@ -129,8 +129,8 @@ inline bool isInf<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isInfPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes [[maybe_unused]],
                                         uint8_t const* dataBytes [[maybe_unused]],
-                                        size_t         scaleIndex [[maybe_unused]],
-                                        size_t         dataIndex [[maybe_unused]])
+                                        index_t         scaleIndex [[maybe_unused]],
+                                        index_t         dataIndex [[maybe_unused]])
 {
     return false;
 }
@@ -138,8 +138,8 @@ inline bool isInfPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes [[maybe_unused
 template <>
 inline bool isZero<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                    uint8_t const* dataBytes,
-                                   size_t         scaleIndex,
-                                   size_t         dataIndex)
+                                   index_t         scaleIndex,
+                                   index_t         dataIndex)
 {
     if(isNaN<ocp_e2m3_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return false;
@@ -151,8 +151,8 @@ inline bool isZero<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline bool isZeroPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                          uint8_t const* dataBytes,
-                                         size_t         scaleIndex,
-                                         size_t         dataIndex)
+                                         index_t         scaleIndex,
+                                         index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e2m3_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return false;
@@ -162,7 +162,7 @@ inline bool isZeroPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 }
 
 template <>
-inline bool isSubnorm<ocp_e2m3_mxfp6>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<ocp_e2m3_mxfp6>(uint8_t const* dataBytes, index_t dataIndex)
 {
     // XXX 6 bit
     uint8_t data = *(dataBytes + dataIndex) & 0b00111111;
@@ -171,7 +171,7 @@ inline bool isSubnorm<ocp_e2m3_mxfp6>(uint8_t const* dataBytes, size_t dataIndex
 }
 
 template <>
-inline bool isSubnormPacked<ocp_e2m3_mxfp6>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<ocp_e2m3_mxfp6>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint8_t data = getDataFromPackedF6(dataBytes, dataIndex);
     return isSubNormal<uint16_t>(
@@ -181,8 +181,8 @@ inline bool isSubnormPacked<ocp_e2m3_mxfp6>(uint8_t const* dataBytes, size_t dat
 template <>
 inline double toDouble<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                        uint8_t const* dataBytes,
-                                       size_t         scaleIndex,
-                                       size_t         dataIndex)
+                                       index_t         scaleIndex,
+                                       index_t         dataIndex)
 {
     if(isNaN<ocp_e2m3_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<double>::quiet_NaN();
@@ -202,8 +202,8 @@ inline double toDouble<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline double toDoublePacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                              uint8_t const* dataBytes,
-                                             size_t         scaleIndex,
-                                             size_t         dataIndex)
+                                             index_t         scaleIndex,
+                                             index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e2m3_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<double>::quiet_NaN();
@@ -223,8 +223,8 @@ inline double toDoublePacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline float toFloat<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                      uint8_t const* dataBytes,
-                                     size_t         scaleIndex,
-                                     size_t         dataIndex)
+                                     index_t         scaleIndex,
+                                     index_t         dataIndex)
 {
     if(isNaN<ocp_e2m3_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -244,8 +244,8 @@ inline float toFloat<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
                                            uint8_t const* dataBytes,
-                                           size_t         scaleIndex,
-                                           size_t         dataIndex)
+                                           index_t         scaleIndex,
+                                           index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e2m3_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -264,7 +264,7 @@ inline float toFloatPacked<ocp_e2m3_mxfp6>(uint8_t const* scaleBytes,
 
 template <>
 inline void setOne<ocp_e2m3_mxfp6>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     *(scaleBytes + scaleIndex)
         = subNormal ? scaleSubNormalOne<ocp_e2m3_mxfp6>() : scaleOne<ocp_e2m3_mxfp6>();
@@ -276,8 +276,8 @@ inline void setOne<ocp_e2m3_mxfp6>(
 template <>
 inline void setZero<ocp_e2m3_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                     uint8_t* dataBytes,
-                                    size_t   scaleIndex [[maybe_unused]],
-                                    size_t   dataIndex)
+                                    index_t   scaleIndex [[maybe_unused]],
+                                    index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = positiveZeroMask<ocp_e2m3_mxfp6>();
 }
@@ -286,8 +286,8 @@ inline void setZero<ocp_e2m3_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<ocp_e2m3_mxfp6>(uint8_t* scaleBytes,
                                    uint8_t* dataBytes [[maybe_unused]],
-                                   size_t   scaleIndex,
-                                   size_t   dataIndex [[maybe_unused]])
+                                   index_t   scaleIndex,
+                                   index_t   dataIndex [[maybe_unused]])
 {
     *(scaleBytes + scaleIndex) = Constants::E8M0_NAN;
 }
@@ -296,15 +296,15 @@ inline void setNaN<ocp_e2m3_mxfp6>(uint8_t* scaleBytes,
 template <>
 inline void setInf<ocp_e2m3_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                    uint8_t* dataBytes [[maybe_unused]],
-                                   size_t   scaleIndex [[maybe_unused]],
-                                   size_t   dataIndex [[maybe_unused]])
+                                   index_t   scaleIndex [[maybe_unused]],
+                                   index_t   dataIndex [[maybe_unused]])
 {
     return;
 }
 
 template <>
 inline void
-    setDataMax<ocp_e2m3_mxfp6>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMax<ocp_e2m3_mxfp6>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         *(dataBytes + dataIndex) = positive ? dataMaxPositiveSubNormalMask<ocp_e2m3_mxfp6>()
@@ -316,7 +316,7 @@ inline void
 
 template <>
 inline void setOnePacked<ocp_e2m3_mxfp6>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     *(scaleBytes + scaleIndex) = subNormal ? Constants::E8M0_3 : Constants::E8M0_1;
     uint8_t mask = subNormal ? dataSubNormalOneMask<ocp_e2m3_mxfp6>() : oneMask<ocp_e2m3_mxfp6>();
@@ -328,8 +328,8 @@ inline void setOnePacked<ocp_e2m3_mxfp6>(
 template <>
 inline void setZeroPacked<ocp_e2m3_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                           uint8_t* dataBytes,
-                                          size_t   scaleIndex [[maybe_unused]],
-                                          size_t   dataIndex)
+                                          index_t   scaleIndex [[maybe_unused]],
+                                          index_t   dataIndex)
 {
     setDataPackedF6(dataBytes, dataIndex, positiveZeroMask<ocp_e2m3_mxfp6>());
 }
@@ -337,8 +337,8 @@ inline void setZeroPacked<ocp_e2m3_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaNPacked<ocp_e2m3_mxfp6>(uint8_t* scaleBytes,
                                          uint8_t* dataBytes [[maybe_unused]],
-                                         size_t   scaleIndex,
-                                         size_t   dataIndex [[maybe_unused]])
+                                         index_t   scaleIndex,
+                                         index_t   dataIndex [[maybe_unused]])
 {
     *(scaleBytes + scaleIndex) = Constants::E8M0_NAN;
 }
@@ -347,15 +347,15 @@ inline void setNaNPacked<ocp_e2m3_mxfp6>(uint8_t* scaleBytes,
 template <>
 inline void setInfPacked<ocp_e2m3_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                          uint8_t* dataBytes [[maybe_unused]],
-                                         size_t   scaleIndex [[maybe_unused]],
-                                         size_t   dataIndex [[maybe_unused]])
+                                         index_t   scaleIndex [[maybe_unused]],
+                                         index_t   dataIndex [[maybe_unused]])
 {
     return;
 }
 
 template <>
 inline void setDataMaxPacked<ocp_e2m3_mxfp6>(uint8_t* dataBytes,
-                                             size_t   dataIndex,
+                                             index_t   dataIndex,
                                              bool     subNormal,
                                              bool     positive)
 {

--- a/lib/include/ocp_e3m2_mxfp6_impl.hpp
+++ b/lib/include/ocp_e3m2_mxfp6_impl.hpp
@@ -97,8 +97,8 @@ inline uint8_t scaleOne<ocp_e3m2_mxfp6>()
 template <>
 inline bool isNaN<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes [[maybe_unused]],
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex [[maybe_unused]])
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex [[maybe_unused]])
 {
     // no need to check for NAN in dataBytes since there's no NAN representation
     return *(scaleBytes + scaleIndex) == Constants::E8M0_NAN;
@@ -107,8 +107,8 @@ inline bool isNaN<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                         uint8_t const* dataBytes,
-                                        size_t         scaleIndex,
-                                        size_t         dataIndex)
+                                        index_t         scaleIndex,
+                                        index_t         dataIndex)
 {
     // since the scale is e8m0 and is 8 bits its packed is the same as unpacked
     // as well as there are no NAN for ocp_e3m2_mxfp6
@@ -118,8 +118,8 @@ inline bool isNaNPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes [[maybe_unused]],
                                   uint8_t const* dataBytes [[maybe_unused]],
-                                  size_t         scaleIndex [[maybe_unused]],
-                                  size_t         dataIndex [[maybe_unused]])
+                                  index_t         scaleIndex [[maybe_unused]],
+                                  index_t         dataIndex [[maybe_unused]])
 {
     // no infinity representation in ocp_e3m2_mxfp6 will always return false
     return false;
@@ -129,8 +129,8 @@ inline bool isInf<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isInfPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes [[maybe_unused]],
                                         uint8_t const* dataBytes [[maybe_unused]],
-                                        size_t         scaleIndex [[maybe_unused]],
-                                        size_t         dataIndex [[maybe_unused]])
+                                        index_t         scaleIndex [[maybe_unused]],
+                                        index_t         dataIndex [[maybe_unused]])
 {
     return false;
 }
@@ -138,8 +138,8 @@ inline bool isInfPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes [[maybe_unused
 template <>
 inline bool isZero<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                    uint8_t const* dataBytes,
-                                   size_t         scaleIndex,
-                                   size_t         dataIndex)
+                                   index_t         scaleIndex,
+                                   index_t         dataIndex)
 {
     if(isNaN<ocp_e3m2_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return false;
@@ -151,8 +151,8 @@ inline bool isZero<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline bool isZeroPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                          uint8_t const* dataBytes,
-                                         size_t         scaleIndex,
-                                         size_t         dataIndex)
+                                         index_t         scaleIndex,
+                                         index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e3m2_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return false;
@@ -162,7 +162,7 @@ inline bool isZeroPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 }
 
 template <>
-inline bool isSubnorm<ocp_e3m2_mxfp6>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<ocp_e3m2_mxfp6>(uint8_t const* dataBytes, index_t dataIndex)
 {
     // XXX 6 bit
     uint8_t data = *(dataBytes + dataIndex) & 0b00111111;
@@ -171,7 +171,7 @@ inline bool isSubnorm<ocp_e3m2_mxfp6>(uint8_t const* dataBytes, size_t dataIndex
 }
 
 template <>
-inline bool isSubnormPacked<ocp_e3m2_mxfp6>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<ocp_e3m2_mxfp6>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint8_t data = getDataFromPackedF6(dataBytes, dataIndex);
     return isSubNormal<uint16_t>(
@@ -181,8 +181,8 @@ inline bool isSubnormPacked<ocp_e3m2_mxfp6>(uint8_t const* dataBytes, size_t dat
 template <>
 inline double toDouble<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                        uint8_t const* dataBytes,
-                                       size_t         scaleIndex,
-                                       size_t         dataIndex)
+                                       index_t         scaleIndex,
+                                       index_t         dataIndex)
 {
     if(isNaN<ocp_e3m2_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<double>::quiet_NaN();
@@ -202,8 +202,8 @@ inline double toDouble<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline double toDoublePacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                              uint8_t const* dataBytes,
-                                             size_t         scaleIndex,
-                                             size_t         dataIndex)
+                                             index_t         scaleIndex,
+                                             index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e3m2_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<double>::quiet_NaN();
@@ -223,8 +223,8 @@ inline double toDoublePacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline float toFloat<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                      uint8_t const* dataBytes,
-                                     size_t         scaleIndex,
-                                     size_t         dataIndex)
+                                     index_t         scaleIndex,
+                                     index_t         dataIndex)
 {
     if(isNaN<ocp_e3m2_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -244,8 +244,8 @@ inline float toFloat<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
                                            uint8_t const* dataBytes,
-                                           size_t         scaleIndex,
-                                           size_t         dataIndex)
+                                           index_t         scaleIndex,
+                                           index_t         dataIndex)
 {
     if(isNaNPacked<ocp_e3m2_mxfp6>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -264,7 +264,7 @@ inline float toFloatPacked<ocp_e3m2_mxfp6>(uint8_t const* scaleBytes,
 
 template <>
 inline void setOne<ocp_e3m2_mxfp6>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     *(scaleBytes + scaleIndex)
         = subNormal ? scaleSubNormalOne<ocp_e3m2_mxfp6>() : scaleOne<ocp_e3m2_mxfp6>();
@@ -276,8 +276,8 @@ inline void setOne<ocp_e3m2_mxfp6>(
 template <>
 inline void setZero<ocp_e3m2_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                     uint8_t* dataBytes,
-                                    size_t   scaleIndex [[maybe_unused]],
-                                    size_t   dataIndex)
+                                    index_t   scaleIndex [[maybe_unused]],
+                                    index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = positiveZeroMask<ocp_e3m2_mxfp6>();
 }
@@ -286,8 +286,8 @@ inline void setZero<ocp_e3m2_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<ocp_e3m2_mxfp6>(uint8_t* scaleBytes,
                                    uint8_t* dataBytes [[maybe_unused]],
-                                   size_t   scaleIndex,
-                                   size_t   dataIndex [[maybe_unused]])
+                                   index_t   scaleIndex,
+                                   index_t   dataIndex [[maybe_unused]])
 {
     *(scaleBytes + scaleIndex) = Constants::E8M0_NAN;
 }
@@ -296,15 +296,15 @@ inline void setNaN<ocp_e3m2_mxfp6>(uint8_t* scaleBytes,
 template <>
 inline void setInf<ocp_e3m2_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                    uint8_t* dataBytes [[maybe_unused]],
-                                   size_t   scaleIndex [[maybe_unused]],
-                                   size_t   dataIndex [[maybe_unused]])
+                                   index_t   scaleIndex [[maybe_unused]],
+                                   index_t   dataIndex [[maybe_unused]])
 {
     return;
 }
 
 template <>
 inline void
-    setDataMax<ocp_e3m2_mxfp6>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMax<ocp_e3m2_mxfp6>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         *(dataBytes + dataIndex) = positive ? dataMaxPositiveSubNormalMask<ocp_e3m2_mxfp6>()
@@ -316,7 +316,7 @@ inline void
 
 template <>
 inline void setOnePacked<ocp_e3m2_mxfp6>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     *(scaleBytes + scaleIndex) = subNormal ? Constants::E8M0_3 : Constants::E8M0_1;
     uint8_t mask = subNormal ? dataSubNormalOneMask<ocp_e3m2_mxfp6>() : oneMask<ocp_e3m2_mxfp6>();
@@ -328,8 +328,8 @@ inline void setOnePacked<ocp_e3m2_mxfp6>(
 template <>
 inline void setZeroPacked<ocp_e3m2_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                           uint8_t* dataBytes,
-                                          size_t   scaleIndex [[maybe_unused]],
-                                          size_t   dataIndex)
+                                          index_t   scaleIndex [[maybe_unused]],
+                                          index_t   dataIndex)
 {
     setDataPackedF6(dataBytes, dataIndex, positiveZeroMask<ocp_e3m2_mxfp6>());
 }
@@ -337,8 +337,8 @@ inline void setZeroPacked<ocp_e3m2_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaNPacked<ocp_e3m2_mxfp6>(uint8_t* scaleBytes,
                                          uint8_t* dataBytes [[maybe_unused]],
-                                         size_t   scaleIndex,
-                                         size_t   dataIndex [[maybe_unused]])
+                                         index_t   scaleIndex,
+                                         index_t   dataIndex [[maybe_unused]])
 {
     *(scaleBytes + scaleIndex) = Constants::E8M0_NAN;
 }
@@ -347,15 +347,15 @@ inline void setNaNPacked<ocp_e3m2_mxfp6>(uint8_t* scaleBytes,
 template <>
 inline void setInfPacked<ocp_e3m2_mxfp6>(uint8_t* scaleBytes [[maybe_unused]],
                                          uint8_t* dataBytes [[maybe_unused]],
-                                         size_t   scaleIndex [[maybe_unused]],
-                                         size_t   dataIndex [[maybe_unused]])
+                                         index_t   scaleIndex [[maybe_unused]],
+                                         index_t   dataIndex [[maybe_unused]])
 {
     return;
 }
 
 template <>
 inline void setDataMaxPacked<ocp_e3m2_mxfp6>(uint8_t* dataBytes,
-                                             size_t   dataIndex,
+                                             index_t   dataIndex,
                                              bool     subNormal,
                                              bool     positive)
 {

--- a/lib/include/ocp_e4m3_mxfp8_impl.hpp
+++ b/lib/include/ocp_e4m3_mxfp8_impl.hpp
@@ -31,8 +31,8 @@
 template <>
 inline bool isNaN<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes,
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex)
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex)
 {
     uint8_t data  = *(dataBytes + dataIndex);
     uint8_t scale = *(scaleBytes + scaleIndex);
@@ -50,8 +50,8 @@ inline bool isNaN<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                         uint8_t const* dataBytes,
-                                        size_t         scaleIndex,
-                                        size_t         dataIndex)
+                                        index_t         scaleIndex,
+                                        index_t         dataIndex)
 {
     return isNaN<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -60,8 +60,8 @@ inline bool isNaNPacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isZero<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                    uint8_t const* dataBytes,
-                                   size_t         scaleIndex,
-                                   size_t         dataIndex)
+                                   index_t         scaleIndex,
+                                   index_t         dataIndex)
 {
     if(isNaN<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return false;
@@ -76,8 +76,8 @@ inline bool isZero<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isZeroPacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                          uint8_t const* dataBytes,
-                                         size_t         scaleIndex,
-                                         size_t         dataIndex)
+                                         index_t         scaleIndex,
+                                         index_t         dataIndex)
 {
     return isZero<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -86,8 +86,8 @@ inline bool isZeroPacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes [[maybe_unused]],
                                   uint8_t const* dataBytes [[maybe_unused]],
-                                  size_t         scaleIndex [[maybe_unused]],
-                                  size_t         dataIndex [[maybe_unused]])
+                                  index_t         scaleIndex [[maybe_unused]],
+                                  index_t         dataIndex [[maybe_unused]])
 {
     return false;
 }
@@ -95,8 +95,8 @@ inline bool isInf<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isInfPacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                         uint8_t const* dataBytes,
-                                        size_t         scaleIndex,
-                                        size_t         dataIndex)
+                                        index_t         scaleIndex,
+                                        index_t         dataIndex)
 {
     return isInf<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -104,8 +104,8 @@ inline bool isInfPacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline double toDouble<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                        uint8_t const* dataBytes,
-                                       size_t         scaleIndex,
-                                       size_t         dataIndex)
+                                       index_t         scaleIndex,
+                                       index_t         dataIndex)
 {
     if(isNaN<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<double>::quiet_NaN();
@@ -124,8 +124,8 @@ inline double toDouble<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline double toDoublePacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                              uint8_t const* dataBytes,
-                                             size_t         scaleIndex,
-                                             size_t         dataIndex)
+                                             index_t         scaleIndex,
+                                             index_t         dataIndex)
 {
     return toDouble<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -133,8 +133,8 @@ inline double toDoublePacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline float toFloat<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                      uint8_t const* dataBytes,
-                                     size_t         scaleIndex,
-                                     size_t         dataIndex)
+                                     index_t         scaleIndex,
+                                     index_t         dataIndex)
 {
     if(isNaN<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -153,14 +153,14 @@ inline float toFloat<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<ocp_e4m3_mxfp8>(uint8_t const* scaleBytes,
                                            uint8_t const* dataBytes,
-                                           size_t         scaleIndex,
-                                           size_t         dataIndex)
+                                           index_t         scaleIndex,
+                                           index_t         dataIndex)
 {
     return toFloat<ocp_e4m3_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
 
 template <>
-inline bool isSubnorm<ocp_e4m3_mxfp8>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<ocp_e4m3_mxfp8>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint8_t data = *(dataBytes + dataIndex);
     return isSubNormal<uint16_t>(
@@ -168,14 +168,14 @@ inline bool isSubnorm<ocp_e4m3_mxfp8>(uint8_t const* dataBytes, size_t dataIndex
 }
 
 template <>
-inline bool isSubnormPacked<ocp_e4m3_mxfp8>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<ocp_e4m3_mxfp8>(uint8_t const* dataBytes, index_t dataIndex)
 {
     return isSubnorm<ocp_e4m3_mxfp8>(dataBytes, dataIndex);
 }
 
 template <>
 inline void setOne<ocp_e4m3_mxfp8>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     //if its sub normal, 0b00000010 * E8M0_135 will equal to 1
     *(scaleBytes + scaleIndex) = subNormal ? Constants::E8M0_135 : Constants::E8M0_1;
@@ -187,8 +187,8 @@ inline void setOne<ocp_e4m3_mxfp8>(
 template <>
 inline void setZero<ocp_e4m3_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
                                     uint8_t* dataBytes,
-                                    size_t   scaleIndex [[maybe_unused]],
-                                    size_t   dataIndex)
+                                    index_t   scaleIndex [[maybe_unused]],
+                                    index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = ocp_e4m3_mxfp8::positiveZeroMask;
 }
@@ -197,8 +197,8 @@ inline void setZero<ocp_e4m3_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<ocp_e4m3_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
                                    uint8_t* dataBytes,
-                                   size_t   scaleIndex [[maybe_unused]],
-                                   size_t   dataIndex)
+                                   index_t   scaleIndex [[maybe_unused]],
+                                   index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = ocp_e4m3_mxfp8::dataNaNMasks[0];
 }
@@ -207,15 +207,15 @@ inline void setNaN<ocp_e4m3_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInf<ocp_e4m3_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
                                    uint8_t* dataBytes [[maybe_unused]],
-                                   size_t   scaleIndex [[maybe_unused]],
-                                   size_t   dataIndex [[maybe_unused]])
+                                   index_t   scaleIndex [[maybe_unused]],
+                                   index_t   dataIndex [[maybe_unused]])
 {
     return;
 }
 
 template <>
 inline void
-    setDataMax<ocp_e4m3_mxfp8>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMax<ocp_e4m3_mxfp8>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         *(dataBytes + dataIndex) = positive ? ocp_e4m3_mxfp8::dataMaxPositiveSubNormalMask

--- a/lib/include/ocp_e5m2_mxfp8_impl.hpp
+++ b/lib/include/ocp_e5m2_mxfp8_impl.hpp
@@ -30,8 +30,8 @@
 template <>
 inline bool isNaN<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                   uint8_t const* dataBytes,
-                                  size_t         scaleIndex,
-                                  size_t         dataIndex)
+                                  index_t         scaleIndex,
+                                  index_t         dataIndex)
 {
     uint8_t data  = *(dataBytes + dataIndex);
     uint8_t scale = *(scaleBytes + scaleIndex);
@@ -49,8 +49,8 @@ inline bool isNaN<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isNaNPacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                         uint8_t const* dataBytes,
-                                        size_t         scaleIndex,
-                                        size_t         dataIndex)
+                                        index_t         scaleIndex,
+                                        index_t         dataIndex)
 {
     return isNaN<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -58,8 +58,8 @@ inline bool isNaNPacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isInf<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes [[maybe_unused]],
                                   uint8_t const* dataBytes,
-                                  size_t         scaleIndex [[maybe_unused]],
-                                  size_t         dataIndex)
+                                  index_t         scaleIndex [[maybe_unused]],
+                                  index_t         dataIndex)
 {
 
     // No need to check the scale since it does not have an inf representation
@@ -74,8 +74,8 @@ inline bool isInf<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes [[maybe_unused]],
 template <>
 inline bool isInfPacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                         uint8_t const* dataBytes,
-                                        size_t         scaleIndex,
-                                        size_t         dataIndex)
+                                        index_t         scaleIndex,
+                                        index_t         dataIndex)
 {
     return isInf<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -83,8 +83,8 @@ inline bool isInfPacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isZero<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                    uint8_t const* dataBytes,
-                                   size_t         scaleIndex,
-                                   size_t         dataIndex)
+                                   index_t         scaleIndex,
+                                   index_t         dataIndex)
 {
 
     if(isNaN<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex))
@@ -100,8 +100,8 @@ inline bool isZero<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline bool isZeroPacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                          uint8_t const* dataBytes,
-                                         size_t         scaleIndex,
-                                         size_t         dataIndex)
+                                         index_t         scaleIndex,
+                                         index_t         dataIndex)
 {
     return isZero<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -109,8 +109,8 @@ inline bool isZeroPacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline double toDouble<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                        uint8_t const* dataBytes,
-                                       size_t         scaleIndex,
-                                       size_t         dataIndex)
+                                       index_t         scaleIndex,
+                                       index_t         dataIndex)
 {
     if(isNaN<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<double>::quiet_NaN();
@@ -138,8 +138,8 @@ inline double toDouble<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline double toDoublePacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                              uint8_t const* dataBytes,
-                                             size_t         scaleIndex,
-                                             size_t         dataIndex)
+                                             index_t         scaleIndex,
+                                             index_t         dataIndex)
 {
     return toDouble<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
@@ -147,8 +147,8 @@ inline double toDoublePacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline float toFloat<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                      uint8_t const* dataBytes,
-                                     size_t         scaleIndex,
-                                     size_t         dataIndex)
+                                     index_t         scaleIndex,
+                                     index_t         dataIndex)
 {
     if(isNaN<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex))
         return std::numeric_limits<float>::quiet_NaN();
@@ -176,14 +176,14 @@ inline float toFloat<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
 template <>
 inline float toFloatPacked<ocp_e5m2_mxfp8>(uint8_t const* scaleBytes,
                                            uint8_t const* dataBytes,
-                                           size_t         scaleIndex,
-                                           size_t         dataIndex)
+                                           index_t         scaleIndex,
+                                           index_t         dataIndex)
 {
     return toFloat<ocp_e5m2_mxfp8>(scaleBytes, dataBytes, scaleIndex, dataIndex);
 }
 
 template <>
-inline bool isSubnorm<ocp_e5m2_mxfp8>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnorm<ocp_e5m2_mxfp8>(uint8_t const* dataBytes, index_t dataIndex)
 {
     uint8_t data = *(dataBytes + dataIndex);
     return isSubNormal<uint8_t>(
@@ -191,14 +191,14 @@ inline bool isSubnorm<ocp_e5m2_mxfp8>(uint8_t const* dataBytes, size_t dataIndex
 }
 
 template <>
-inline bool isSubnormPacked<ocp_e5m2_mxfp8>(uint8_t const* dataBytes, size_t dataIndex)
+inline bool isSubnormPacked<ocp_e5m2_mxfp8>(uint8_t const* dataBytes, index_t dataIndex)
 {
     return isSubnorm<ocp_e5m2_mxfp8>(dataBytes, dataIndex);
 }
 
 template <>
 inline void setOne<ocp_e5m2_mxfp8>(
-    uint8_t* scaleBytes, uint8_t* dataBytes, size_t scaleIndex, size_t dataIndex, bool subNormal)
+    uint8_t* scaleBytes, uint8_t* dataBytes, index_t scaleIndex, index_t dataIndex, bool subNormal)
 {
     *(scaleBytes + scaleIndex) = subNormal ? Constants::E8M0_142 : Constants::E8M0_1;
     *(dataBytes + dataIndex)
@@ -208,8 +208,8 @@ inline void setOne<ocp_e5m2_mxfp8>(
 template <>
 inline void setZero<ocp_e5m2_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
                                     uint8_t* dataBytes,
-                                    size_t   scaleIndex [[maybe_unused]],
-                                    size_t   dataIndex)
+                                    index_t   scaleIndex [[maybe_unused]],
+                                    index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = ocp_e5m2_mxfp8::positiveZeroMask;
 }
@@ -217,8 +217,8 @@ inline void setZero<ocp_e5m2_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setNaN<ocp_e5m2_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
                                    uint8_t* dataBytes,
-                                   size_t   scaleIndex [[maybe_unused]],
-                                   size_t   dataIndex)
+                                   index_t   scaleIndex [[maybe_unused]],
+                                   index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = ocp_e5m2_mxfp8::dataNaNMasks[0];
 }
@@ -226,15 +226,15 @@ inline void setNaN<ocp_e5m2_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
 template <>
 inline void setInf<ocp_e5m2_mxfp8>(uint8_t* scaleBytes [[maybe_unused]],
                                    uint8_t* dataBytes,
-                                   size_t   scaleIndex [[maybe_unused]],
-                                   size_t   dataIndex)
+                                   index_t   scaleIndex [[maybe_unused]],
+                                   index_t   dataIndex)
 {
     *(dataBytes + dataIndex) = ocp_e5m2_mxfp8::positiveInfMask;
 }
 
 template <>
 inline void
-    setDataMax<ocp_e5m2_mxfp8>(uint8_t* dataBytes, size_t dataIndex, bool subNormal, bool positive)
+    setDataMax<ocp_e5m2_mxfp8>(uint8_t* dataBytes, index_t dataIndex, bool subNormal, bool positive)
 {
     if(subNormal)
         *(dataBytes + dataIndex) = positive ? ocp_e5m2_mxfp8::dataMaxPositiveSubNormalMask

--- a/lib/include/packing.hpp
+++ b/lib/include/packing.hpp
@@ -26,9 +26,9 @@
 
 #pragma once
 
-inline uint16_t getDataFP16(const uint8_t* dataBytes, int index)
+inline uint16_t getDataFP16(const uint8_t* dataBytes, index_t index)
 {
-    int cellIndex = index * 2;
+    index_t cellIndex = index * 2;
 
     uint16_t lsb = dataBytes[cellIndex];
     uint16_t msb = dataBytes[cellIndex + 1];
@@ -36,9 +36,9 @@ inline uint16_t getDataFP16(const uint8_t* dataBytes, int index)
     return (msb << 8) | lsb;
 }
 
-inline void setDataFP16(uint8_t* dataBytes, int index, uint16_t mask)
+inline void setDataFP16(uint8_t* dataBytes, index_t index, uint16_t mask)
 {
-    int cellIndex = index * 2;
+    index_t cellIndex = index * 2;
 
     uint8_t lsb = mask & 0b11111111;
     uint8_t msb = mask >> 8;


### PR DESCRIPTION
For all indexing, use 64-bit integers. This will enable using larger matrices.

Improved the performance of testing by adding openmp support in more locations.

This PR was based on previous work done by @jaopaulolc 